### PR TITLE
pipeline: add `git describe ref` and custom shell script as optional tagging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Currently, Cycloid console doesn't support yet switching between different pipel
 |`registry_password`|Password for regular image repository, otherwise leave it as a empty string.|`string`|`secret`|`False`|
 |`registry_tag`|tag to put on the builded image (eg latest).|`string`|`($ environment $)`|`True`|
 |`registry_tag_commit_id`|Add additionnal tag using short commit id|`bool`|`false`|`False`|
+|`registry_tag_describe_ref`|Add additional tag using git describe ref: `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).|`bool`|`false`|`False`|
 |`registry_username`|Username for regular image repository, otherwise leave it as a empty string.|`string`|`myuser`|`False`|
 |`stack_git_branch`|Branch to use on the public stack git repository|`-`|`master`|`True`|
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Currently, Cycloid console doesn't support yet switching between different pipel
 |`registry_password`|Password for regular image repository, otherwise leave it as a empty string.|`string`|`secret`|`False`|
 |`registry_tag`|tag to put on the builded image (eg latest).|`string`|`($ environment $)`|`True`|
 |`registry_tag_commit_id`|Add additionnal tag using short commit id|`bool`|`false`|`False`|
+|`registry_tag_custom_script`|Add additional tags using a `.ci/tag_custom_script.sh` shell script.|`bool`|`false`|`False`|
 |`registry_tag_describe_ref`|Add additional tag using git describe ref: `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).|`bool`|`false`|`False`|
 |`registry_username`|Username for regular image repository, otherwise leave it as a empty string.|`string`|`myuser`|`False`|
 |`stack_git_branch`|Branch to use on the public stack git repository|`-`|`master`|`True`|

--- a/docker/.ci/tag_custom_script.sh
+++ b/docker/.ci/tag_custom_script.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+declare -a tags
+DIR=$(dirname $(readlink -f $0))
+
+# extract tag from VERSION file
+#tags+=( "$(cat ${DIR}/../VERSION)" )
+
+# extract tag from package.json
+#tags+=( "$(jq -r ".version" < ${DIR}/../package.json)" )
+
+# extract tag from pom.xml
+#pip${PYTHON_VERSION} install -q --no-cache-dir yq
+#tags+=( "$(xq -r ".project.version" < ${DIR}/../pom.xml)" )
+
+# the script must be a space-separated string list of tags (eg. `tag1 tag2`)
+printf "%s " "${tags[@]}" | xargs

--- a/pipeline/pipeline-split-jobs.yml
+++ b/pipeline/pipeline-split-jobs.yml
@@ -19,10 +19,11 @@ shared:
         echo rc-$(cat config/.git/short_ref) > merged-stack/TAGS-RC
 
         declare -a tags
-        [[ "$TAG_COMMIT_ID" == "true" ]] && tags+=( "$(cat config/.git/short_ref)" )
+        [[ "$TAG_CUSTOM_SCRIPT" == "true" ]] && tags+=( $(bash merged-stack/.ci/tag_custom_script.sh) )
         [[ "$TAG_DESCRIBE_REF" == "true" ]] && tags+=( "$(cat config/.git/describe_ref)" )
+        [[ "$TAG_COMMIT_ID" == "true" ]] && tags+=( "$(cat config/.git/short_ref)" )
         [[ -n "$EXTRA_TAGS" ]] && tags+=( ${EXTRA_TAGS} )
-        printf "%s " "${tags[@]}" > merged-stack/.ci/TAGS
+        printf "%s " "${tags[@]}" | xargs > merged-stack/.ci/TAGS
 
         if [ -n "$BUILD_ARGS" ] && [[ "$BUILD_ARGS" != "null" ]]; then
           python -c "import json, os, yaml; print('\n'.join([ '%s=%s' % (k,v) for k, v in json.loads(os.environ['BUILD_ARGS'].replace('\\n','\\\\\\\n')).items()]))" >> merged-stack/.ci/build_args_file
@@ -226,6 +227,7 @@ jobs:
       EXTRA_TAGS: ((registry_extra_tags))
       TAG_COMMIT_ID: ((registry_tag_commit_id))
       TAG_DESCRIBE_REF: ((registry_tag_describe_ref))
+      TAG_CUSTOM_SCRIPT: ((registry_tag_custom_script))
 
   - put: image
     params:

--- a/pipeline/pipeline-split-jobs.yml
+++ b/pipeline/pipeline-split-jobs.yml
@@ -10,17 +10,20 @@ shared:
     #run:
     #  path: /usr/bin/merge-stack-and-config
     run:
-      path: /bin/sh
+      path: /bin/bash
       args:
       - -c
       - |
         /usr/bin/merge-stack-and-config
+
         echo rc-$(cat config/.git/short_ref) > merged-stack/TAGS-RC
-        if [[ "$TAG_COMMIT_ID" == "true" ]]; then
-          echo ${EXTRA_TAGS} $(cat config/.git/short_ref) > merged-stack/.ci/TAGS
-        else
-          echo ${EXTRA_TAGS} > merged-stack/.ci/TAGS
-        fi
+
+        declare -a tags
+        [[ "$TAG_COMMIT_ID" == "true" ]] && tags+=( "$(cat config/.git/short_ref)" )
+        [[ "$TAG_DESCRIBE_REF" == "true" ]] && tags+=( "$(cat config/.git/describe_ref)" )
+        [[ -n "$EXTRA_TAGS" ]] && tags+=( ${EXTRA_TAGS} )
+        printf "%s " "${tags[@]}" > merged-stack/.ci/TAGS
+
         if [ -n "$BUILD_ARGS" ] && [[ "$BUILD_ARGS" != "null" ]]; then
           python -c "import json, os, yaml; print('\n'.join([ '%s=%s' % (k,v) for k, v in json.loads(os.environ['BUILD_ARGS'].replace('\\n','\\\\\\\n')).items()]))" >> merged-stack/.ci/build_args_file
         fi
@@ -29,6 +32,12 @@ shared:
         path: "merged-stack"
 
 resource_types:
+
+- name: git
+  type: docker-image
+  source:
+    repository: concourse/git-resource
+    tag: latest
 
 - name: registry-image
   type: docker-image
@@ -93,9 +102,6 @@ jobs:
     params:
       CONFIG_PATH: ((code_build_context))
       STACK_PATH: docker
-      EXTRA_TAGS: ((registry_extra_tags))
-      BUILD_ARGS: ((code_build_args))
-      TAG_COMMIT_ID: ((registry_tag_commit_id))
 
   - task: tests
     file: merged-stack/.ci/tests.yml
@@ -111,6 +117,8 @@ jobs:
       passed:
       - tests
     - get: git_code
+      params:
+        describe_ref_options: --always --tags
       trigger: true
       passed:
       - tests
@@ -126,9 +134,7 @@ jobs:
     params:
       CONFIG_PATH: ((code_build_context))
       STACK_PATH: docker
-      EXTRA_TAGS: ((registry_extra_tags))
       BUILD_ARGS: ((code_build_args))
-      TAG_COMMIT_ID: ((registry_tag_commit_id))
 
   - task: build
     file: merged-stack/.ci/build.yml
@@ -176,9 +182,6 @@ jobs:
     params:
       CONFIG_PATH: ((code_build_context))
       STACK_PATH: docker
-      EXTRA_TAGS: ((registry_extra_tags))
-      BUILD_ARGS: ((code_build_args))
-      TAG_COMMIT_ID: ((registry_tag_commit_id))
 
   - task: post-tests
     file: merged-stack/.ci/post-tests.yml
@@ -197,6 +200,8 @@ jobs:
       passed:
       - post-tests
     - get: git_code
+      params:
+        describe_ref_options: --always --tags
       trigger: false
       passed:
       - post-tests
@@ -219,8 +224,8 @@ jobs:
       CONFIG_PATH: ((code_build_context))
       STACK_PATH: docker
       EXTRA_TAGS: ((registry_extra_tags))
-      BUILD_ARGS: ((code_build_args))
       TAG_COMMIT_ID: ((registry_tag_commit_id))
+      TAG_DESCRIBE_REF: ((registry_tag_describe_ref))
 
   - put: image
     params:

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -17,10 +17,11 @@ shared:
         /usr/bin/merge-stack-and-config
 
         declare -a tags
-        [[ "$TAG_COMMIT_ID" == "true" ]] && tags+=( "$(cat config/.git/short_ref)" )
+        [[ "$TAG_CUSTOM_SCRIPT" == "true" ]] && tags+=( $(bash merged-stack/.ci/tag_custom_script.sh) )
         [[ "$TAG_DESCRIBE_REF" == "true" ]] && tags+=( "$(cat config/.git/describe_ref)" )
+        [[ "$TAG_COMMIT_ID" == "true" ]] && tags+=( "$(cat config/.git/short_ref)" )
         [[ -n "$EXTRA_TAGS" ]] && tags+=( ${EXTRA_TAGS} )
-        printf "%s " "${tags[@]}" > merged-stack/.ci/TAGS
+        printf "%s " "${tags[@]}" | xargs > merged-stack/.ci/TAGS
 
         if [ -n "$BUILD_ARGS" ] && [[ "$BUILD_ARGS" != "null" ]]; then
           python -c "import json, os, yaml; print('\n'.join([ '%s=%s' % (k,v) for k, v in json.loads(os.environ['BUILD_ARGS'].replace('\\n','\\\\\\\n')).items()]))" >> merged-stack/.ci/build_args_file
@@ -106,6 +107,7 @@ jobs:
       EXTRA_TAGS: ((registry_extra_tags))
       TAG_COMMIT_ID: ((registry_tag_commit_id))
       TAG_DESCRIBE_REF: ((registry_tag_describe_ref))
+      TAG_CUSTOM_SCRIPT: ((registry_tag_custom_script))
 
   - task: tests
     file: merged-stack/.ci/tests.yml

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -10,16 +10,18 @@ shared:
     #run:
     #  path: /usr/bin/merge-stack-and-config
     run:
-      path: /bin/sh
+      path: /bin/bash
       args:
       - -c
       - |
         /usr/bin/merge-stack-and-config
-        if [[ "$TAG_COMMIT_ID" == "true" ]]; then
-          echo ${EXTRA_TAGS} $(cat config/.git/short_ref) > merged-stack/.ci/TAGS
-        else
-          echo ${EXTRA_TAGS} > merged-stack/.ci/TAGS
-        fi
+
+        declare -a tags
+        [[ "$TAG_COMMIT_ID" == "true" ]] && tags+=( "$(cat config/.git/short_ref)" )
+        [[ "$TAG_DESCRIBE_REF" == "true" ]] && tags+=( "$(cat config/.git/describe_ref)" )
+        [[ -n "$EXTRA_TAGS" ]] && tags+=( ${EXTRA_TAGS} )
+        printf "%s " "${tags[@]}" > merged-stack/.ci/TAGS
+
         if [ -n "$BUILD_ARGS" ] && [[ "$BUILD_ARGS" != "null" ]]; then
           python -c "import json, os, yaml; print('\n'.join([ '%s=%s' % (k,v) for k, v in json.loads(os.environ['BUILD_ARGS'].replace('\\n','\\\\\\\n')).items()]))" >> merged-stack/.ci/build_args_file
         fi
@@ -28,6 +30,12 @@ shared:
         path: "merged-stack"
 
 resource_types:
+
+- name: git
+  type: docker-image
+  source:
+    repository: concourse/git-resource
+    tag: latest
 
 - name: registry-image
   type: docker-image
@@ -79,6 +87,8 @@ jobs:
     - get: git_stack
       trigger: true
     - get: git_code
+      params:
+        describe_ref_options: --always --tags
       trigger: true
 
   - task: merge-stack-and-config
@@ -92,9 +102,10 @@ jobs:
     params:
       CONFIG_PATH: ((code_build_context))
       STACK_PATH: docker
-      EXTRA_TAGS: ((registry_extra_tags))
       BUILD_ARGS: ((code_build_args))
+      EXTRA_TAGS: ((registry_extra_tags))
       TAG_COMMIT_ID: ((registry_tag_commit_id))
+      TAG_DESCRIBE_REF: ((registry_tag_describe_ref))
 
   - task: tests
     file: merged-stack/.ci/tests.yml

--- a/pipeline/variables.sample.yml
+++ b/pipeline/variables.sample.yml
@@ -42,6 +42,10 @@ registry_tag_commit_id: false
 #+ Add additional tag using git describe ref: `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).
 registry_tag_describe_ref: false
 
+#. registry_tag_custom_script (optional, bool): false
+#+ Add additional tags using a `.ci/tag_custom_script.sh` shell script.
+registry_tag_custom_script: false
+
 
 #
 # Repos

--- a/pipeline/variables.sample.yml
+++ b/pipeline/variables.sample.yml
@@ -38,6 +38,10 @@ registry_extra_tags: ''
 #+ Add additionnal tag using short commit id
 registry_tag_commit_id: false
 
+#. registry_tag_described_ref (optional, bool): false
+#+ Add additional tag using git describe ref: `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).
+registry_tag_describe_ref: false
+
 
 #
 # Repos


### PR DESCRIPTION
Add two new options for advanced docker image tagging:
* `registry_tag_custom_script`: Add additional tags using a `.ci/tag_custom_script.sh` shell script
* `registry_tag_describe_ref`: Add additional tag using git describe ref: `<latest annoted git tag>-<the number of commit since the tag>-g<short_ref>` (eg. `v1.6.2-1-g13dfd7b`).