### PR TITLE
docker/ci: switch to the cycloid/concourse-dind docker image for the …

### DIFF
--- a/docker/.ci/post-tests.yml
+++ b/docker/.ci/post-tests.yml
@@ -1,24 +1,21 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: docker
-    tag: 17.12.0-dind
+    repository: cycloid/concourse-dind
+    tag: latest
 run:
-  path: /bin/sh
+  path: concourse-dind-entrypoint.sh
   args:
-    - '-xc'
+    - 'bash'
+    - '-ec'
     - |
-      /usr/local/bin/dockerd-entrypoint.sh --log-level error 2> docker.log &
-      timeout -t 60 sh -c "until docker info >/dev/null 2>&1; do echo waiting for docker to come up...; sleep 1; done"
-      mount | grep "none on /tmp type tmpfs" && umount /tmp
-      docker load -q -i image/image.tar | awk -F': ' '{print $2}' | tee image/name
-      docker inspect $(cat image/name)
+      source /opt/docker-utils.sh
+      docker_load image/image.tar
 
-      rc=$?
-      pkill -TERM dockerd
-      exit $rc
+      docker images | awk -F' ' '{print $1":"$2}' | tail -1 | tee image/name
+      docker inspect $(cat image/name)
 inputs:
 - name: merged-stack
 - name: image


### PR DESCRIPTION
…post-tests